### PR TITLE
[WIP] Delete unused files

### DIFF
--- a/lib/generators/app/index.js
+++ b/lib/generators/app/index.js
@@ -13,18 +13,10 @@ var JasmineGenerator = module.exports = yeoman.generators.Base.extend({
   },
 
   writing: function () {
-    this.copy('_bower.json', 'test/bower.json');
-    this.copy('bowerrc', 'test/.bowerrc');
     this.copy('test.js', 'test/spec/test.js');
-    this.copy('index.html', 'test/index.html');
   },
 
   install: function () {
     process.chdir('test');
-    this.installDependencies({
-      npm: false,
-      skipInstall: this.options['skip-install']
-    });
   }
-
 });

--- a/test/test.js
+++ b/test/test.js
@@ -20,10 +20,7 @@ describe('Jasmine generator test', function () {
 
   it('creates expected files', function (done) {
     var expected = [
-      'spec/test.js',
-      '.bowerrc',
-      'bower.json',
-      'index.html'
+      'spec/test.js'
     ];
 
     this.app.options['skip-install'] = true;


### PR DESCRIPTION
It seems that installed jasmine@1.x by generator-jasmine is not used in generator-webapp.

jasmine@2 is include in grunt-contrib-jasmine installed by generator-webapp. This is generating test target's html file, it is no necessary index.html and jasmine@1 installed by generator-jasmine.

However, I do not know whether other generator is the same as generator-webapp.

```
$ mkdir webapp1 && cd $_
$ yo webapp --test-framework=jasmine
$ rm -rf test/.bowerrc test/bower.json test/index.html test/bower_components
$ grunt test
...

Running "jasmine:all" (jasmine) task
Testing jasmine specs via PhantomJS

 Give it some context
   maybe a bit more context here
     - should run here few assertions...
log: Spec 'Give it some context maybe a bit more context here should run here few assertions' has no expectations.
     ✓ should run here few assertions

1 spec in 0.114s.
>> 0 failures

Done, without errors.
...
```